### PR TITLE
Store the old packages between reboots

### DIFF
--- a/tasks/upgrade/main.fmf
+++ b/tasks/upgrade/main.fmf
@@ -1,2 +1,3 @@
 summary: Upgrade the distro
 order: 20
+duration: 30m

--- a/tasks/upgrade/task.sh
+++ b/tasks/upgrade/task.sh
@@ -11,6 +11,7 @@ rlJournalStart
     rlPhaseStartTest "Update"
         if [[ "$TMT_REBOOT_COUNT" == "0" ]]; then
             rlRun "rpm -qa | sort | tee old" 0 "Check packages before update"
+            rlFileSubmit old
             rlRun "dnf --refresh update -y" 0 "Update to the latest packages"
             rlRun "dnf upgrade -y" 0 "Update to the latest packages"
             rlRun "dnf install dnf-plugin-system-upgrade -y" 0 "Install dnf upgrade plugin"
@@ -19,7 +20,7 @@ rlJournalStart
         else
             rlLog "Successfully rebooted"
             rlRun "rpm -qa | sort | tee new" 0 "Check packages after update"
-            rlRun "diff old new" 1 "Compare package lists"
+            rlRun "diff $TMT_TEST_DATA/old new" 1 "Compare package lists"
         fi
     rlPhaseEnd
 


### PR DESCRIPTION
I somehow forgot to commit this part. The old packages are stored in the cwd (which is only a temporary directory) and hence not kept between reboots, we need to store it to the data directory.