### PR TITLE
Update Fedora versions in update paths

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,5 +2,5 @@ jobs:
   - job: tests
     trigger: pull_request
     metadata:
-        targets: [fedora-35]
+        targets: [fedora-36]
         skip_build: true

--- a/paths/fedora36to37.fmf
+++ b/paths/fedora36to37.fmf
@@ -1,12 +1,12 @@
-summary: Upgrade from Fedora 35 to Fedora 36
+summary: Upgrade from Fedora 36 to Fedora 37
 discover:
     how: fmf
     filter: "tag:fedora"
 provision:
     how: virtual
-    image: fedora-35
+    image: fedora-36
 environment:
-    SOURCE: 35
-    TARGET: 36
+    SOURCE: 36
+    TARGET: 37
 execute:
     how: tmt

--- a/tasks/upgrade/task.sh
+++ b/tasks/upgrade/task.sh
@@ -15,6 +15,9 @@ rlJournalStart
             rlRun "dnf --refresh update -y" 0 "Update to the latest packages"
             rlRun "dnf upgrade -y" 0 "Update to the latest packages"
             rlRun "dnf install dnf-plugin-system-upgrade -y" 0 "Install dnf upgrade plugin"
+            if dnf repolist | grep testing-farm-tag-repository; then
+                rlRun "dnf config-manager --disable testing-farm-tag-repository"
+            fi
             rlRun "dnf system-upgrade download --releasever=$TARGET -y" 0 "Download new Fedora packages"
             rlRun "tmt-reboot -c \"dnf system-upgrade reboot\" -t 1800" 0 "Start actual upgrade"
         else


### PR DESCRIPTION
As Fedora 35 is now EOL we need to refresh versions.