### PR TITLE
Prepare a couple of future upgrade paths

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,5 +2,5 @@ jobs:
   - job: tests
     trigger: pull_request
     metadata:
-        targets: [fedora-36]
+        targets: [fedora-37]
         skip_build: true

--- a/paths/fedora38to39.fmf
+++ b/paths/fedora38to39.fmf
@@ -1,0 +1,12 @@
+summary: Upgrade from Fedora 38 to Fedora 39
+discover:
+    how: fmf
+    filter: "tag:fedora"
+provision:
+    how: virtual
+    image: fedora-38
+environment:
+    SOURCE: 38
+    TARGET: 39
+execute:
+    how: tmt

--- a/paths/fedora39to40.fmf
+++ b/paths/fedora39to40.fmf
@@ -1,12 +1,12 @@
-summary: Upgrade from Fedora 36 to Fedora 37
+summary: Upgrade from Fedora 39 to Fedora 40
 discover:
     how: fmf
     filter: "tag:fedora"
 provision:
     how: virtual
-    image: fedora-36
+    image: fedora-39
 environment:
-    SOURCE: 36
-    TARGET: 37
+    SOURCE: 39
+    TARGET: 40
 execute:
     how: tmt

--- a/paths/fedora40to41.fmf
+++ b/paths/fedora40to41.fmf
@@ -1,0 +1,12 @@
+summary: Upgrade from Fedora 40 to Fedora 41
+discover:
+    how: fmf
+    filter: "tag:fedora"
+provision:
+    how: virtual
+    image: fedora-40
+environment:
+    SOURCE: 40
+    TARGET: 41
+execute:
+    how: tmt


### PR DESCRIPTION
In order to keep the integration testing with `tmt` working.