### PR TITLE
Run upgrade via `dnf5 offline reboot`

### DIFF
--- a/tasks/upgrade/task.sh
+++ b/tasks/upgrade/task.sh
@@ -19,7 +19,11 @@ rlJournalStart
                 rlRun "dnf config-manager --disable testing-farm-tag-repository"
             fi
             rlRun "dnf system-upgrade download --releasever=$TARGET -y" 0 "Download new Fedora packages"
-            rlRun "tmt-reboot -c \"dnf system-upgrade reboot\" -t 1800" 0 "Start actual upgrade"
+            if [ "$TARGET" -ge 42 ]; then
+                rlRun "tmt-reboot -c \"dnf5 -y offline reboot\" -t 1800" 0 "Start actual upgrade"
+            else
+                rlRun "tmt-reboot -c \"dnf system-upgrade reboot\" -t 1800" 0 "Start actual upgrade"
+            fi
         else
             rlLog "Successfully rebooted"
             rlRun "rpm -qa | sort | tee new" 0 "Check packages after update"

--- a/tasks/upgrade/task.sh
+++ b/tasks/upgrade/task.sh
@@ -19,11 +19,7 @@ rlJournalStart
                 rlRun "dnf config-manager --disable testing-farm-tag-repository"
             fi
             rlRun "dnf system-upgrade download --releasever=$TARGET -y" 0 "Download new Fedora packages"
-            if [ "$TARGET" -ge 42 ]; then
-                rlRun "tmt-reboot -c \"dnf5 -y offline reboot\" -t 1800" 0 "Start actual upgrade"
-            else
-                rlRun "tmt-reboot -c \"dnf system-upgrade reboot\" -t 1800" 0 "Start actual upgrade"
-            fi
+            rlRun "tmt-reboot -c \"dnf5 -y offline reboot\" -t 1800" 0 "Start actual upgrade"
         else
             rlLog "Successfully rebooted"
             rlRun "rpm -qa | sort | tee new" 0 "Check packages after update"


### PR DESCRIPTION
Since `fedora-42` the command `dnf5 offline reboot` is to be used for starting the upgrade.

* https://docs.fedoraproject.org/en-US/quick-docs/upgrading-fedora-offline/