### PR TITLE
Use a different package for dependency test

### DIFF
--- a/tasks/prepare/main.fmf
+++ b/tasks/prepare/main.fmf
@@ -1,3 +1,7 @@
 summary: Prepare distro for the upgrade
-require: dummy-test-package-crested
+description:
+    Require the `tree` package so that `/tests/execute/upgrade`
+    from the main `tmt` repo can verify the dependencies are
+    correctly installed.
+require: tree
 order: 10


### PR DESCRIPTION
The `dummy-test-package-crested` package is no more maintained, let's use a different one.

Related pull request:

* https://github.com/teemtee/tmt/pull/4725