### PR TITLE
dnf5 offline reboot

### DIFF
--- a/tasks/prepare/main.fmf
+++ b/tasks/prepare/main.fmf
@@ -1,3 +1,7 @@
 summary: Prepare distro for the upgrade
-require: dummy-test-package-crested
+description:
+    Require the `tree` package so that `/tests/execute/upgrade`
+    from the main `tmt` repo can verify the dependencies are
+    correctly installed.
+require: tree
 order: 10

--- a/tasks/upgrade/task.sh
+++ b/tasks/upgrade/task.sh
@@ -19,7 +19,7 @@ rlJournalStart
                 rlRun "dnf config-manager --disable testing-farm-tag-repository"
             fi
             rlRun "dnf system-upgrade download --releasever=$TARGET -y" 0 "Download new Fedora packages"
-            rlRun "tmt-reboot -c \"dnf system-upgrade reboot\" -t 1800" 0 "Start actual upgrade"
+            rlRun "tmt-reboot -c \"dnf5 offline reboot\" -t 1800" 0 "Start actual upgrade"
         else
             rlLog "Successfully rebooted"
             rlRun "rpm -qa | sort | tee new" 0 "Check packages after update"


### PR DESCRIPTION
- **Use a different package for dependency test**
- **add proper way to reboot https://docs.fedoraproject.org/en-US/quick-docs/upgrading-fedora-offline/**
