### PR TITLE
Use `dnf config-manager setopt` to disable repositories

### DIFF
--- a/tasks/upgrade/task.sh
+++ b/tasks/upgrade/task.sh
@@ -16,7 +16,7 @@ rlJournalStart
             rlRun "dnf upgrade -y" 0 "Update to the latest packages"
             rlRun "dnf install dnf-plugin-system-upgrade -y" 0 "Install dnf upgrade plugin"
             if dnf repolist | grep testing-farm-tag-repository; then
-                rlRun "dnf config-manager --disable testing-farm-tag-repository"
+                rlRun "dnf config-manager setopt testing-farm-tag-repository.enabled=0"
             fi
             rlRun "dnf system-upgrade download --releasever=$TARGET -y" 0 "Download new Fedora packages"
             rlRun "tmt-reboot -c \"dnf5 -y offline reboot\" -t 1800" 0 "Start actual upgrade"


### PR DESCRIPTION
it was depreciated, now you have to use **setopt**
[changes_from_dnf4.7](https://dnf5.readthedocs.io/en/latest/changes_from_dnf4.7.html#changes-to-individual-options)

[config-manager](https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html)
_search dnf5 config-manager setopt_

current way is deprecated and does not work
```
[root@ip-172-31-20-52 ~]# dnf config-manager --disable testing-farm-tag-repository
Unknown argument "--disable" for command "config-manager". Add "--help" for more information about the arguments.
[root@ip-172-31-20-52 ~]# dnf repolist | grep testing-farm-tag-repository
testing-farm-tag-repository Tag repository for f43-build
[root@ip-172-31-20-52 ~]# dnf config-manager setopt testing-farm-tag-repository.enabled=0
[root@ip-172-31-20-52 ~]# dnf repolist | grep testing-farm-tag-repository
```
